### PR TITLE
Release stag to main 2026-05-31 (1)

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -5,15 +5,13 @@ RUN apk add --no-cache git bash curl
 
 WORKDIR /app
 
-RUN npm install -g pnpm
-
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json package-lock.json ./
+RUN npm install
 
 COPY . .
 
 # Gera o build estático para web
-RUN pnpm exec expo export --platform web
+RUN npx expo export --platform web
 
 # Etapa 2: Servir com nginx
 FROM nginx:alpine


### PR DESCRIPTION
## Descrição

This pull request updates the production Docker build process to use `npm` instead of `pnpm` for dependency management and build commands. The change simplifies the build steps and aligns the Docker configuration with standard Node.js practices.

Dependency management and build process:

* Replaced installation of `pnpm` with direct use of `npm`, updated the files copied for dependency installation to `package.json` and `package-lock.json`, and switched the install command from `pnpm install --frozen-lockfile` to `npm install`.
* Changed the static web build command from `pnpm exec expo export --platform web` to `npx expo export --platform web` to use `npx` with `npm`.

## Tipo de Mudança

- [ ] Correção de Bug
- [ ] Nova Funcionalidade
- [ ] Refatoração
- [ ] Documentação
- [x] Outro (especifique): Deploy

## Checklist

- [ ] Meu código segue as diretrizes de estilo do projeto
- [ ] Executei `npm run lint` e não há erros
- [ ] Adicionei testes que comprovam minha correção/melhoria
- [ ] Atualizei a documentação relacionada

## Lista de Alterações de Dependências

N/A

## Capturas de Tela (se aplicável)

N/A

## Contexto Adicional

N/A
