### PR TITLE
Feat/img bb proxy for s3

### DIFF
--- a/src/stores/User/User.ts
+++ b/src/stores/User/User.ts
@@ -308,24 +308,29 @@ export const useUserStore = create<UserStore>()(
           const responseFetch = await fetch(imageUri);
           const blob = await responseFetch.blob();
 
-          const uploadResponse = await fetch(uploadUrl, {
-            method: 'PUT',
-            body: blob,
-            headers: { 'Content-Type': 'image/jpeg' },
-          });
+          const isProxyUpload = uploadUrl.startsWith('/api/');
 
-          if (!uploadResponse.ok) throw new Error('Falha no upload');
-
-          // S3: PUT retorna vazio → usa fileUrl do POST
-          // ImgBB proxy: PUT retorna { fileUrl } com a URL real do ImgBB
           let fileUrl = initialFileUrl;
-          // Verifica se content-type indica resposta JSON (caso do ImgBB proxy)
-          const contentType = uploadResponse.headers.get('content-type');
-          if (contentType?.includes('application/json')) {
-            const responseData = await uploadResponse.json();
-            if (responseData?.fileUrl) {
-              fileUrl = responseData.fileUrl;
-            }
+
+          if (isProxyUpload) {
+            // Proxy ImgBB — usa backendHttpClient que já tem a baseURL configurada
+            const proxyRes = await backendHttpClient.put<{ fileUrl?: string }>(
+              uploadUrl,
+              blob,
+              {
+                headers: { 'Content-Type': 'image/jpeg' },
+              },
+            );
+            if (proxyRes.data?.fileUrl) fileUrl = proxyRes.data.fileUrl;
+          } else {
+            // S3 — PUT direto na AWS
+            const uploadResponse = await fetch(uploadUrl, {
+              method: 'PUT',
+              body: blob,
+              headers: { 'Content-Type': 'image/jpeg' },
+            });
+            if (!uploadResponse.ok)
+              throw new Error('Falha no upload para o bucket S3');
           }
 
           await backendHttpClient.patch('/api/avatar/update-path', {

--- a/src/stores/User/User.ts
+++ b/src/stores/User/User.ts
@@ -299,7 +299,7 @@ export const useUserStore = create<UserStore>()(
         try {
           const fileName = `avatar_${Date.now()}.jpg`;
           const {
-            data: { uploadUrl, fileUrl },
+            data: { uploadUrl, fileUrl: initialFileUrl },
           } = await backendHttpClient.post('/api/avatar/upload-url', {
             fileName,
             fileType: 'image/jpeg',
@@ -314,8 +314,19 @@ export const useUserStore = create<UserStore>()(
             headers: { 'Content-Type': 'image/jpeg' },
           });
 
-          if (!uploadResponse.ok)
-            throw new Error('Falha no upload para o bucket S3');
+          if (!uploadResponse.ok) throw new Error('Falha no upload');
+
+          // S3: PUT retorna vazio → usa fileUrl do POST
+          // ImgBB proxy: PUT retorna { fileUrl } com a URL real do ImgBB
+          let fileUrl = initialFileUrl;
+          // Verifica se content-type indica resposta JSON (caso do ImgBB proxy)
+          const contentType = uploadResponse.headers.get('content-type');
+          if (contentType?.includes('application/json')) {
+            const responseData = await uploadResponse.json();
+            if (responseData?.fileUrl) {
+              fileUrl = responseData.fileUrl;
+            }
+          }
 
           await backendHttpClient.patch('/api/avatar/update-path', {
             avatar_uri: fileUrl,


### PR DESCRIPTION
## Descrição

This pull request updates the avatar upload logic in the `useUserStore` store to support both S3 and proxy (ImgBB) upload flows. The main changes improve how the upload destination is detected and handled, ensuring the correct upload method is used and the resulting file URL is set appropriately.

**Avatar upload logic improvements:**

* The code now checks if `uploadUrl` starts with `/api/` to determine if the upload should be proxied through the backend (e.g., ImgBB) or sent directly to S3.
* For proxy uploads, it uses `backendHttpClient.put` to upload the image and updates the final `fileUrl` if the backend response provides one.
* For S3 uploads, it performs a direct `PUT` request and throws an error if the upload fails, as before.
* Renamed the destructured `fileUrl` from the upload URL response to `initialFileUrl` to clarify its role before possible reassignment.

## Tipo de Mudança

- [ ] Correção de Bug
- [ ] Nova Funcionalidade
- [x] Refatoração
- [ ] Documentação
- [ ] Outro (especifique)

## Checklist

- [x] Meu código segue as diretrizes de estilo do projeto
- [ ] Executei `npm run lint` e não há erros
- [ ] Adicionei testes que comprovam minha correção/melhoria
- [ ] Atualizei a documentação relacionada

## Lista de Alterações de Dependências

N/A

## Capturas de Tela (se aplicável)

N/A

## Contexto Adicional

N/A